### PR TITLE
fix: seom date parsing with .net framework 6

### DIFF
--- a/Money.Core/Services/SeomStatementParser.cs
+++ b/Money.Core/Services/SeomStatementParser.cs
@@ -34,7 +34,7 @@ namespace Money.Core.Services
       var invoiceDateLine = lines.First(line => line.StartsWith("Fakturadatum"));
 
       DateTime dateTime;
-      DateTime.TryParseExact(invoiceDateLine.Substring(13), "d MMM yyyy", new CultureInfo("sv-SE"), DateTimeStyles.None, out dateTime);
+      DateTime.TryParseExact(invoiceDateLine.Substring(13).Trim(), "d MMM yyyy", CustomCultureInfo, DateTimeStyles.None, out dateTime);
 
       return dateTime;
     }
@@ -58,6 +58,17 @@ namespace Money.Core.Services
         return false;
       expense = new Expense { Description = line.Split(' ').First(), Amount = amount };
       return true;
+    }
+
+    private static CultureInfo CustomCultureInfo
+    {
+      get
+      {
+        var cultureInfo = CultureInfo.GetCultures(CultureTypes.AllCultures).FirstOrDefault(c => c.LCID == 29).Clone() as CultureInfo;
+        cultureInfo.DateTimeFormat.AbbreviatedMonthNames = cultureInfo.DateTimeFormat.AbbreviatedMonthNames.Select(x => x.TrimEnd('.')).ToArray();
+        cultureInfo.DateTimeFormat.AbbreviatedMonthGenitiveNames = cultureInfo.DateTimeFormat.AbbreviatedMonthGenitiveNames.Select(x => x.TrimEnd('.')).ToArray();
+        return cultureInfo;
+      }
     }
   }
 }

--- a/Money.Tests/SeomStatementParserTests.cs
+++ b/Money.Tests/SeomStatementParserTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using Money.Core.Models;
+using Money.Core.Services;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Money.Tests
+{
+  public class SeomStatementParserTests
+  {
+    private readonly ITestOutputHelper _output;
+
+    public SeomStatementParserTests(ITestOutputHelper output)
+    {
+      _output = output;
+    }
+
+    [Fact]
+    public void CanParse_WhenAbleToParseNewStatement_ReturnsTrue()
+    {
+      var statement = new Statement
+      {
+        Lines = new[] { "Fakturadatum             7 okt 2024", "Vatten 15,90 kr" }
+      };
+
+      var result = new SeomStatementParser().Parse(statement);
+      Assert.True(result.Any());
+      _output.WriteLine(result.FirstOrDefault().Date.ToString(), result.FirstOrDefault().Amount.ToString());
+    }
+  }
+}


### PR DESCRIPTION
.NET Core 6 globalization APIs has changed to use ICU libraries instead of the old NLS libraries. This breaks the parsing of Swedish dates like "6 okt 2024".

https://learn.microsoft.com/en-us/dotnet/core/compatibility/globalization/5.0/icu-globalization-api
