### PR TITLE
fix: custom month abbreviations for seom date parser

### DIFF
--- a/Money.Core/Services/SeomStatementParser.cs
+++ b/Money.Core/Services/SeomStatementParser.cs
@@ -65,7 +65,7 @@ namespace Money.Core.Services
       get
       {
         var cultureInfo = CultureInfo.GetCultures(CultureTypes.AllCultures).FirstOrDefault(c => c.LCID == 29).Clone() as CultureInfo;
-        cultureInfo.DateTimeFormat.AbbreviatedMonthNames = cultureInfo.DateTimeFormat.AbbreviatedMonthNames.Select(x => x.TrimEnd('.')).ToArray();
+        cultureInfo.DateTimeFormat.AbbreviatedMonthNames = new List<string> { "jan", "feb", "mar", "apr", "maj", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" }.ToArray();
         cultureInfo.DateTimeFormat.AbbreviatedMonthGenitiveNames = cultureInfo.DateTimeFormat.AbbreviatedMonthGenitiveNames.Select(x => x.TrimEnd('.')).ToArray();
         return cultureInfo;
       }


### PR DESCRIPTION
Previous custom `CultureInfo` did not handle month "mar". Now the list of abbreviations is fully customized to work with all SEOM dates.